### PR TITLE
Tweak the default acccess log format

### DIFF
--- a/xsnippet/web_backend/__main__.py
+++ b/xsnippet/web_backend/__main__.py
@@ -12,4 +12,9 @@ logger = logging.getLogger('aiohttp').setLevel(logging.INFO)
 
 # create an app instance and listen forever
 app = create_app(conf)
-aiohttp.web.run_app(app, host=conf.LISTEN_HOST, port=conf.LISTEN_PORT)
+aiohttp.web.run_app(
+    app,
+    host=conf.LISTEN_HOST,
+    port=conf.LISTEN_PORT,
+    access_log_format=conf.ACCESS_LOG_FORMAT
+)

--- a/xsnippet/web_backend/conf.py
+++ b/xsnippet/web_backend/conf.py
@@ -5,3 +5,5 @@ API_URL = os.environ.get('XSNIPPET_API_URL', 'http://api.xsnippet.org')
 
 LISTEN_HOST = os.environ.get('XSNIPPET_WEB_PROXY_HOST', '0.0.0.0')
 LISTEN_PORT = os.environ.get('XSNIPPET_WEB_PROXY_PORT', 5000)
+
+ACCESS_LOG_FORMAT = os.environ.get('ACCESS_LOG_FORMAT', '%t %a "%r" %s %b "%{User-Agent}i" %Tf')


### PR DESCRIPTION
Make sure we've got the most important information like remote addr,
request status line, response code, response size, user agent and
request processing time, e.g:

```
[10/Jan/2018:21:04:46 +0000] 127.0.0.1 "GET /snippets/42/raw HTTP/1.1" 200 154 "curl/7.54.0" 0.100991
```

Note, that for production deploys behind a reverse-proxy this format
might be changed to use the HTTP headers like X-Real-IP or
X-Forwarded-For, if needed.